### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/plugins/multivendorx/src/blocks/contact-info/index.js
+++ b/plugins/multivendorx/src/blocks/contact-info/index.js
@@ -9,7 +9,6 @@ import {
 	PanelRow,
 } from '@wordpress/components';
 import {
-	InnerBlocks,
 	InspectorControls,
 	useBlockProps,
 } from '@wordpress/block-editor';


### PR DESCRIPTION
To fix the problem, we should remove the unused `InnerBlocks` import from the destructuring import of `@wordpress/block-editor`. This avoids having dead code, improves readability, and removes the CodeQL warning, without altering the functional behavior of the block.

Concretely, in `plugins/multivendorx/src/blocks/contact-info/index.js`, locate the import block at the top of the file where `InnerBlocks`, `InspectorControls`, and `useBlockProps` are imported from `@wordpress/block-editor`. Modify that import to remove `InnerBlocks` from the list, leaving only `InspectorControls` and `useBlockProps`. No other code changes, additional imports, or method definitions are needed, because `InnerBlocks` is not used elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._