### PR TITLE
Potential fix for code scanning alert no. 10: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/packages/js/zyra/src/components/CustomRecaptcha.tsx
+++ b/packages/js/zyra/src/components/CustomRecaptcha.tsx
@@ -7,10 +7,17 @@ const CustomRecaptcha = ( props: any ) => {
     const [ isCaptchaValid, setIsCaptchaValid ] = useState( true );
 
     useEffect( () => {
-        // Generate a cryptographically secure random 6-digit code
+        // Generate a cryptographically secure random 6-digit code without modulo bias
         const generateCode = () => {
-            const randomValue = window.crypto.getRandomValues( new Uint32Array( 1 ) )[ 0 ];
-            return ( 100000 + ( randomValue % 900000 ) ).toString();
+            const range = 900000; // 100000..999999 inclusive
+            const maxUnbiased = Math.floor( 0x100000000 / range ) * range;
+            let randomValue = 0;
+
+            do {
+                randomValue = window.crypto.getRandomValues( new Uint32Array( 1 ) )[ 0 ];
+            } while ( randomValue >= maxUnbiased );
+
+            return ( 100000 + ( randomValue % range ) ).toString();
         };
 
         setSecurityCode( generateCode() );


### PR DESCRIPTION
Potential fix for [https://github.com/multivendorx/multivendorx/security/code-scanning/10](https://github.com/multivendorx/multivendorx/security/code-scanning/10)

Use `crypto.getRandomValues` with rejection sampling so the sampled value is uniformly distributed in `[0, 899999]`, then add `100000`.  
Best fix in this file: replace the modulo-based generation in `generateCode` with:

1. Compute `range = 900000`.
2. Compute `maxUnbiased = Math.floor(0x100000000 / range) * range` (largest multiple of range below `2^32`).
3. Draw 32-bit values until `randomValue < maxUnbiased`.
4. Return `(100000 + (randomValue % range)).toString()`.

This preserves behavior (still a 6-digit string from `100000` to `999999`) while removing modulo bias.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
