### PR TITLE
Fix for Overwritten property

### DIFF
--- a/plugins/catalogx/src/assets/template/CrimsonValley.tsx
+++ b/plugins/catalogx/src/assets/template/CrimsonValley.tsx
@@ -234,7 +234,6 @@ export const CrimsonValley = {
 							color: '#7c2d2d',
 							fontWeight: '700',
 							marginBottom: 0.25,
-							paddingTop: 0.5,
 							borderTop: '2px solid #fef2f2',
 							paddingTop: 1.25,
 						},


### PR DESCRIPTION
The correct fix is to keep only the intended `paddingTop` value in the `summary-title` style object and remove the duplicate declaration that gets overwritten.

Best single fix (no functional change):  
- In `plugins/catalogx/src/assets/template/CrimsonValley.tsx`, locate the `style` object for block `id: 14` (`name: 'summary-title'`).
- Remove the earlier `paddingTop: 0.5` line.
- Keep `paddingTop: 1.25` as the effective value, since that is already what runtime uses today.

No imports, new methods, or new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._