### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/packages/js/zyra/src/components/FileInput.tsx
+++ b/packages/js/zyra/src/components/FileInput.tsx
@@ -43,6 +43,31 @@ const isImageFile = (url: string): boolean =>
         /\.(jpg|jpeg|png|gif|webp|svg|bmp)$/i
     ) !== null;
 
+const sanitizeFileUrl = (url?: string): string => {
+    if (!url) {
+        return '';
+    }
+
+    const trimmed = url.trim();
+    if (!trimmed) {
+        return '';
+    }
+
+    // Allow browser-generated blob URLs, absolute http(s), and relative paths.
+    if (
+        trimmed.startsWith('blob:') ||
+        trimmed.startsWith('http://') ||
+        trimmed.startsWith('https://') ||
+        trimmed.startsWith('/') ||
+        trimmed.startsWith('./') ||
+        trimmed.startsWith('../')
+    ) {
+        return trimmed;
+    }
+
+    return '';
+};
+
 export const FileInputUI: React.FC<FileInputProps> = (props) => {
     const inputRef = useRef<HTMLInputElement>(null);
     const [files, setFiles] = useState<FileItem[]>([]);
@@ -237,7 +262,7 @@ export const FileInputUI: React.FC<FileInputProps> = (props) => {
             {props.multiple && files.length > 0 && (
                 <div className="uploaded-image">
                     {files.map((file, i) => {
-                        const fileSrc = file.url;
+                        const fileSrc = sanitizeFileUrl(file.url);
                         const isActive = i === activeIndex;
 
                         return (


### PR DESCRIPTION
Potential fix for [https://github.com/multivendorx/multivendorx/security/code-scanning/6](https://github.com/multivendorx/multivendorx/security/code-scanning/6)

To fix this safely without changing intended behavior, validate/sanitize file URLs before using them in `src`. Only allow expected schemes (for this component: `blob:`, `http:`, `https:`, and relative URLs), and fall back to a safe empty value for anything else. This prevents dangerous schemes (for example `javascript:`) or malformed values from reaching DOM URL sinks.

Best single approach in this file:
- Add a small helper (near `isImageFile`) to normalize and allowlist URL schemes.
- Use that helper when deriving `fileSrc` in the render loop (line region around 240).
- Keep existing UI logic unchanged (image/file icon decision, dimensions, remove behavior).

No new dependency is required; use built-in string checks / `URL` parsing conservatively.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
