### PR TITLE
Potential fix for code scanning alert no. 24: Double escaping or unescaping

### DIFF
--- a/packages/js/zyra/src/components/table/Utill.tsx
+++ b/packages/js/zyra/src/components/table/Utill.tsx
@@ -126,11 +126,11 @@ export const renderCell = (
             const withoutTags = rawValue.replace(/<[^>]*>/g, ' ');
             const decodedText = withoutTags
                 .replace(/&nbsp;/gi, ' ')
-                .replace(/&amp;/gi, '&')
                 .replace(/&lt;/gi, '<')
                 .replace(/&gt;/gi, '>')
                 .replace(/&quot;/gi, '"')
-                .replace(/&#39;/gi, "'");
+                .replace(/&#39;/gi, "'")
+                .replace(/&amp;/gi, '&');
             const cleanText = decodedText.replace(/\s+/g, ' ').trim();
 
             const shortText =


### PR DESCRIPTION
Potential fix for [https://github.com/multivendorx/multivendorx/security/code-scanning/24](https://github.com/multivendorx/multivendorx/security/code-scanning/24)

To fix double-unescaping, decode `&amp;` **last** in the chain.  
General rule: when unescaping entities manually, unescape the escape character (`&amp;`) at the end so it cannot create new decodable entities mid-process.

Best minimal fix (no functional redesign): in `packages/js/zyra/src/components/table/Utill.tsx`, inside `case 'content'`, reorder the replacements so `&amp;` is the final replacement. Keep all existing behavior otherwise.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
